### PR TITLE
Improve return type specificity

### DIFF
--- a/dist/spawn.d.ts
+++ b/dist/spawn.d.ts
@@ -5,24 +5,11 @@ interface AwaitSpawnOptions extends SpawnOptions {
     rejectOnExitCode?: boolean;
     input?: string;
 }
-export declare function spawn(command: string, args?: string[], options?: AwaitSpawnOptions): {
+interface AwaitSpawnProcess<T> extends Promise<T> {
     process: ChildProcess;
-} & {
-    [key: string]: any;
-};
+}
+export declare function spawn(command: string, args?: string[], options?: AwaitSpawnOptions): AwaitSpawnProcess<unknown>;
 export default spawn;
-export declare const verbose: (command: string, args?: string[], options?: AwaitSpawnOptions) => {
-    process: ChildProcess;
-} & {
-    [key: string]: any;
-};
-export declare const stderr: (command: string, args?: string[], options?: AwaitSpawnOptions) => {
-    process: ChildProcess;
-} & {
-    [key: string]: any;
-};
-export declare const silent: (command: string, args?: string[], options?: AwaitSpawnOptions) => {
-    process: ChildProcess;
-} & {
-    [key: string]: any;
-};
+export declare const verbose: (command: string, args?: string[], options?: AwaitSpawnOptions) => AwaitSpawnProcess<unknown>;
+export declare const stderr: (command: string, args?: string[], options?: AwaitSpawnOptions) => AwaitSpawnProcess<unknown>;
+export declare const silent: (command: string, args?: string[], options?: AwaitSpawnOptions) => AwaitSpawnProcess<unknown>;

--- a/dist/spawn.d.ts
+++ b/dist/spawn.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="node" />
 import { SpawnOptions, ChildProcess } from "child_process";
-interface AwaitSpawnOptions extends SpawnOptions {
+export interface AwaitSpawnOptions extends SpawnOptions {
     captureStdio?: boolean;
     rejectOnExitCode?: boolean;
     input?: string;
 }
-interface AwaitSpawnProcess<T> extends Promise<T> {
+export interface AwaitSpawnProcess<T> extends Promise<T> {
     process: ChildProcess;
 }
 export declare function spawn(command: string, args?: string[], options?: AwaitSpawnOptions): AwaitSpawnProcess<unknown>;

--- a/dist/spawn.d.ts
+++ b/dist/spawn.d.ts
@@ -1,20 +1,28 @@
 /// <reference types="node" />
-import { SpawnOptions } from "child_process";
+import { SpawnOptions, ChildProcess } from "child_process";
 interface AwaitSpawnOptions extends SpawnOptions {
     captureStdio?: boolean;
     rejectOnExitCode?: boolean;
     input?: string;
 }
-export declare function spawn(command: string, args?: string[], options?: AwaitSpawnOptions): Promise<unknown> & {
-    process: any;
+export declare function spawn(command: string, args?: string[], options?: AwaitSpawnOptions): {
+    process: ChildProcess;
+} & {
+    [key: string]: any;
 };
 export default spawn;
-export declare const verbose: (command: string, args?: string[], options?: AwaitSpawnOptions) => Promise<unknown> & {
-    process: any;
+export declare const verbose: (command: string, args?: string[], options?: AwaitSpawnOptions) => {
+    process: ChildProcess;
+} & {
+    [key: string]: any;
 };
-export declare const stderr: (command: string, args?: string[], options?: AwaitSpawnOptions) => Promise<unknown> & {
-    process: any;
+export declare const stderr: (command: string, args?: string[], options?: AwaitSpawnOptions) => {
+    process: ChildProcess;
+} & {
+    [key: string]: any;
 };
-export declare const silent: (command: string, args?: string[], options?: AwaitSpawnOptions) => Promise<unknown> & {
-    process: any;
+export declare const silent: (command: string, args?: string[], options?: AwaitSpawnOptions) => {
+    process: ChildProcess;
+} & {
+    [key: string]: any;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@await/spawn",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Asynchronous spawn, captures stdio.",
   "main": "./dist/spawn.js",
   "repository": {

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -12,11 +12,15 @@ interface AwaitSpawnOptions extends SpawnOptions {
   input?: string;
 }
 
+interface AwaitSpawnProcess<T> extends Promise<T> {
+  process: ChildProcess;
+}
+
 export function spawn(
   command: string,
   args?: string[],
   options?: AwaitSpawnOptions
-): { process: ChildProcess } & { [key: string]: any } {
+): AwaitSpawnProcess<unknown> {
   let child = null;
   let finishError = prepareFutureError(command, new ExitCodeError());
   return Object.assign(

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -6,13 +6,13 @@ import {
 } from "child_process";
 import { Stream } from "stream";
 
-interface AwaitSpawnOptions extends SpawnOptions {
+export interface AwaitSpawnOptions extends SpawnOptions {
   captureStdio?: boolean;
   rejectOnExitCode?: boolean;
   input?: string;
 }
 
-interface AwaitSpawnProcess<T> extends Promise<T> {
+export interface AwaitSpawnProcess<T> extends Promise<T> {
   process: ChildProcess;
 }
 

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -2,6 +2,7 @@ import {
   spawn as spawn_native,
   SpawnOptions,
   StdioOptions,
+  ChildProcess,
 } from "child_process";
 import { Stream } from "stream";
 
@@ -15,7 +16,7 @@ export function spawn(
   command: string,
   args?: string[],
   options?: AwaitSpawnOptions
-) {
+): { process: ChildProcess } & { [key: string]: any } {
   let child = null;
   let finishError = prepareFutureError(command, new ExitCodeError());
   return Object.assign(


### PR DESCRIPTION
This PR changes the return type from await/spawn from a promise of `unknown` type, to include the property `process` with the type `ChildProcess`, which significantly increases the utility of types on this function.